### PR TITLE
Check current versionName format

### DIFF
--- a/lib/fastlane/plugin/android_versioning/actions/increment_version_name.rb
+++ b/lib/fastlane/plugin/android_versioning/actions/increment_version_name.rb
@@ -10,6 +10,7 @@ module Fastlane
       def self.run(params)
         if params[:version_name].nil? or params[:version_name].empty?
           current_version = GetVersionNameAction.run(params)
+          UI.user_error!("Your current version (#{current_version}) does not respect the format A.B.C") unless current_version =~ /\d+.\d+.\d+/
           version = current_version.split(".").map(&:to_i)
           case params[:bump_type]
           when "patch"


### PR DESCRIPTION
If `versionName` is invalid format, show this below error.
```ruby
NoMethodError: [!] undefined method `+' for nil:NilClass
```

So, check version format and handle error gracefully in this PR.
Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/otkmnb2783/fastlane-plugin-android_versioning/1)
<!-- Reviewable:end -->
