### PR TITLE
fix app_folder_name recursivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # android_versioning plugin
 
 [![fastlane Plugin Badge](https://rawcdn.githack.com/fastlane/fastlane/master/fastlane/assets/plugin-badge.svg)](https://rubygems.org/gems/fastlane-plugin-android_versioning)
+[![Gem Version](https://badge.fury.io/rb/fastlane-plugin-android_versioning.svg)](https://badge.fury.io/rb/fastlane-plugin-android_versioning)
 
 ## Getting Started
 

--- a/lib/fastlane/plugin/android_versioning/actions/get_value_from_build.rb
+++ b/lib/fastlane/plugin/android_versioning/actions/get_value_from_build.rb
@@ -4,10 +4,10 @@ module Fastlane
   module Actions
     class GetValueFromBuildAction < Action
       def self.run(params)
-        app_folder_name ||= params[:app_folder_name]
+        app_project_dir ||= params[:app_project_dir]
         value = ""
         found = false
-        Dir.glob("**/#{app_folder_name}/build.gradle") do |path|
+        Dir.glob("#{app_project_dir}/build.gradle") do |path|
           begin
             File.open(path, 'r') do |file|
               file.each_line do |line|
@@ -30,12 +30,12 @@ module Fastlane
       #####################################################
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :app_folder_name,
-                                  env_name: "ANDROID_VERSIONING_APP_FOLDER_NAME",
-                               description: "The name of the application source folder in the Android project (default: app)",
+          FastlaneCore::ConfigItem.new(key: :app_project_dir,
+                                  env_name: "ANDROID_VERSIONING_APP_PROJECT_DIR",
+                               description: "The path to the application source folder in the Android project (default: android/app)",
                                   optional: true,
                                       type: String,
-                             default_value: "app"),
+                             default_value: "android/app"),
           FastlaneCore::ConfigItem.new(key: :key,
                                description: "The property key",
                                       type: String)

--- a/lib/fastlane/plugin/android_versioning/actions/get_version_code.rb
+++ b/lib/fastlane/plugin/android_versioning/actions/get_version_code.rb
@@ -5,7 +5,7 @@ module Fastlane
     class GetVersionCodeAction < Action
       def self.run(params)
         GetValueFromBuildAction.run(
-          app_folder_name: params[:app_folder_name],
+          app_project_dir: params[:app_project_dir],
           key: "versionCode"
         )
       end
@@ -15,12 +15,12 @@ module Fastlane
       #####################################################
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :app_folder_name,
-                                    env_name: "ANDROID_VERSIONING_APP_FOLDER_NAME",
-                                 description: "The name of the application source folder in the Android project (default: app)",
+          FastlaneCore::ConfigItem.new(key: :app_project_dir,
+                                    env_name: "ANDROID_VERSIONING_APP_PROJECT_DIR",
+                                 description: "The path to the application source folder in the Android project (default: android/app)",
                                     optional: true,
                                         type: String,
-                               default_value: "app")
+                               default_value: "android/app")
         ]
       end
 

--- a/lib/fastlane/plugin/android_versioning/actions/get_version_name.rb
+++ b/lib/fastlane/plugin/android_versioning/actions/get_version_name.rb
@@ -5,7 +5,7 @@ module Fastlane
     class GetVersionNameAction < Action
       def self.run(params)
         GetValueFromBuildAction.run(
-          app_folder_name: params[:app_folder_name],
+          app_project_dir: params[:app_project_dir],
           key: "versionName"
         )
       end
@@ -15,12 +15,12 @@ module Fastlane
       #####################################################
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :app_folder_name,
-                                    env_name: "ANDROID_VERSIONING_APP_FOLDER_NAME",
-                                 description: "The name of the application source folder in the Android project (default: app)",
+          FastlaneCore::ConfigItem.new(key: :app_project_dir,
+                                    env_name: "ANDROID_VERSIONING_APP_PROJECT_DIR",
+                                 description: "The path to the application source folder in the Android project (default: android/app)",
                                     optional: true,
                                         type: String,
-                               default_value: "app")
+                               default_value: "android/app")
         ]
       end
 

--- a/lib/fastlane/plugin/android_versioning/actions/increment_version_code.rb
+++ b/lib/fastlane/plugin/android_versioning/actions/increment_version_code.rb
@@ -11,7 +11,7 @@ module Fastlane
         current_version_code = GetVersionCodeAction.run(params)
         new_version_code = params[:version_code].nil? || params[:version_code].empty? ? current_version_code.to_i + 1 : params[:version_code].to_i
         SetValueInBuildAction.run(
-          app_folder_name: params[:app_folder_name],
+          app_project_dir: params[:app_project_dir],
           key: "versionCode",
           value: new_version_code
         )
@@ -24,12 +24,12 @@ module Fastlane
       #####################################################
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :app_folder_name,
-                                    env_name: "ANDROID_VERSIONING_APP_FOLDER_NAME",
-                                 description: "The name of the application source folder in the Android project (default: app)",
+          FastlaneCore::ConfigItem.new(key: :app_project_dir,
+                                    env_name: "ANDROID_VERSIONING_APP_PROJECT_DIR",
+                                 description: "The path to the application source folder in the Android project (default: android/app)",
                                     optional: true,
                                         type: String,
-                               default_value: "app"),
+                               default_value: "android/app"),
           FastlaneCore::ConfigItem.new(key: :version_code,
                                   env_name: "ANDROID_VERSIONING_VERSION_CODE",
                                description: "Change to a specific version (optional)",

--- a/lib/fastlane/plugin/android_versioning/actions/increment_version_name.rb
+++ b/lib/fastlane/plugin/android_versioning/actions/increment_version_name.rb
@@ -30,7 +30,7 @@ module Fastlane
           new_version = params[:version_name]
         end
         SetValueInBuildAction.run(
-          app_folder_name: params[:app_folder_name],
+          app_project_dir: params[:app_project_dir],
           key: "versionName",
           value: new_version
         )
@@ -43,12 +43,12 @@ module Fastlane
       #####################################################
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :app_folder_name,
-                                  env_name: "ANDROID_VERSIONING_APP_FOLDER_NAME",
-                               description: "The name of the application source folder in the Android project (default: app)",
+          FastlaneCore::ConfigItem.new(key: :app_project_dir,
+                                  env_name: "ANDROID_VERSIONING_APP_PROJECT_DIR",
+                               description: "The path to the application source folder in the Android project (default: android/app)",
                                   optional: true,
                                       type: String,
-                             default_value: "app"),
+                             default_value: "android/app"),
           FastlaneCore::ConfigItem.new(key: :bump_type,
                                   env_name: "ANDROID_VERSIONING_BUMP_TYPE",
                                description: "Change to a specific type (optional)",

--- a/lib/fastlane/plugin/android_versioning/actions/increment_version_name.rb
+++ b/lib/fastlane/plugin/android_versioning/actions/increment_version_name.rb
@@ -10,6 +10,7 @@ module Fastlane
       def self.run(params)
         if params[:version_name].nil? or params[:version_name].empty?
           current_version = GetVersionNameAction.run(params)
+          UI.user_error!("Your current version (#{current_version}) does not respect the format A.B.C") unless current_version =~ /\d+.\d+.\d+/
           version = current_version.split(".").map(&:to_i)
           case params[:bump_type]
           when "patch"

--- a/lib/fastlane/plugin/android_versioning/actions/set_value_in_build.rb
+++ b/lib/fastlane/plugin/android_versioning/actions/set_value_in_build.rb
@@ -5,9 +5,9 @@ module Fastlane
   module Actions
     class SetValueInBuildAction < Action
       def self.run(params)
-        app_folder_name ||= params[:app_folder_name]
+        app_project_dir ||= params[:app_project_dir]
         found = false
-        Dir.glob("**/#{app_folder_name}/build.gradle") do |path|
+        Dir.glob("**/#{app_project_dir}/build.gradle") do |path|
           begin
             temp_file = Tempfile.new('versioning')
             File.open(path, 'r') do |file|
@@ -37,12 +37,12 @@ module Fastlane
       #####################################################
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :app_folder_name,
-                                  env_name: "ANDROID_VERSIONING_APP_FOLDER_NAME",
-                               description: "The name of the application source folder in the Android project (default: app)",
+          FastlaneCore::ConfigItem.new(key: :app_project_dir,
+                                  env_name: "ANDROID_VERSIONING_APP_PROJECT_DIR",
+                               description: "The path to the application source folder in the Android project (default: android/app)",
                                   optional: true,
                                       type: String,
-                             default_value: "app"),
+                             default_value: "android/app"),
           FastlaneCore::ConfigItem.new(key: :key,
                                description: "The property key",
                                       type: String),

--- a/spec/get_version_code_spec.rb
+++ b/spec/get_version_code_spec.rb
@@ -15,7 +15,7 @@ describe Fastlane::Actions::GetVersionCodeAction do
     it "should return verson code from sample/build.gradle" do
       result = Fastlane::FastFile.new.parse("lane :test do
         get_version_code(
-          app_folder_name: \"sample\"
+          app_project_dir: \"sample\"
         )
       end").runner.execute(:test)
       expect(result).to eq("67890")

--- a/spec/get_version_name_spec.rb
+++ b/spec/get_version_name_spec.rb
@@ -15,7 +15,7 @@ describe Fastlane::Actions::GetVersionNameAction do
     it "should return verson name from sample/build.gradle" do
       result = Fastlane::FastFile.new.parse("lane :test do
         get_version_name(
-          app_folder_name: \"sample\"
+          app_project_dir: \"sample\"
         )
       end").runner.execute(:test)
       expect(result).to eq("2.0.0")

--- a/spec/increment_version_code_spec.rb
+++ b/spec/increment_version_code_spec.rb
@@ -24,7 +24,7 @@ describe Fastlane::Actions::IncrementVersionCodeAction do
     it "should return incremented verson code from sample/build.gradle" do
       result = Fastlane::FastFile.new.parse("lane :test do
         increment_version_code(
-          app_folder_name: \"sample\"
+          app_project_dir: \"sample\"
         )
       end").runner.execute(:test)
       expect(result).to eq("67891")

--- a/spec/increment_version_name_spec.rb
+++ b/spec/increment_version_name_spec.rb
@@ -42,7 +42,7 @@ describe Fastlane::Actions::IncrementVersionNameAction do
     it "should return incremented verson code from sample/build.gradle" do
       result = Fastlane::FastFile.new.parse("lane :test do
         increment_version_name(
-          app_folder_name: \"sample\"
+          app_project_dir: \"sample\"
         )
       end").runner.execute(:test)
       expect(result).to eq("2.0.1")


### PR DESCRIPTION
Currently, the `get_value_from_build` action of this plugin will recursively step through all found `build.gradle` files and take the LAST found occurrence of `:key` which (imo) is not the expected behaviour.

Example: (Logging added by me)
![image](https://user-images.githubusercontent.com/17108667/27905394-12d38f72-6240-11e7-8873-95afe0b980b8.png)

@yyoshiki41 forked and created a fix for this bug and also added more sensible defaults. 👏 
@otkmnb2783 Would you be open to this PR?