### PR TITLE
Rework line replace functionality to support empty strings

### DIFF
--- a/lib/fastlane/plugin/android_versioning/actions/get_value_from_build.rb
+++ b/lib/fastlane/plugin/android_versioning/actions/get_value_from_build.rb
@@ -5,17 +5,17 @@ module Fastlane
     class GetValueFromBuildAction < Action
       def self.run(params)
         app_project_dir ||= params[:app_project_dir]
+        regex = Regexp.new(/(?<key>#{params[:key]}\s+)(?<left>[\'\"]?)(?<value>[a-zA-Z0-9\.\_]*)(?<right>[\'\"]?)(?<comment>.*)/)
         value = ""
         found = false
         Dir.glob("#{app_project_dir}/build.gradle") do |path|
           begin
             File.open(path, 'r') do |file|
               file.each_line do |line|
-                unless line.include? "#{params[:key]} " and !found
+                unless line.match(regex) and !found
                   next
                 end
-                components = line.strip.split(' ').reject { |item| item.start_with?("//") }
-                value = components.last.tr("\"", "").tr("\'", "")
+                key, left, value, right, comment = line.match(regex).captures
                 break
               end
               file.close

--- a/lib/fastlane/plugin/android_versioning/actions/set_value_in_build.rb
+++ b/lib/fastlane/plugin/android_versioning/actions/set_value_in_build.rb
@@ -6,7 +6,6 @@ module Fastlane
     class SetValueInBuildAction < Action
       def self.run(params)
         app_project_dir ||= params[:app_project_dir]
-        puts "searching for version code: #{params[:key]}"
         regex = Regexp.new("(#{params[:key]}\\s+)([\'\"])?.*([\'\"])")
         found = false
 

--- a/lib/fastlane/plugin/android_versioning/actions/set_value_in_build.rb
+++ b/lib/fastlane/plugin/android_versioning/actions/set_value_in_build.rb
@@ -6,9 +6,8 @@ module Fastlane
     class SetValueInBuildAction < Action
       def self.run(params)
         app_project_dir ||= params[:app_project_dir]
-        regex = Regexp.new("(#{params[:key]}\\s+)([\'\"])?.*([\'\"])")
+        regex = Regexp.new(/(?<key>#{params[:key]}\s+)(?<left>[\'\"]?)(?<value>[a-zA-Z0-9\.\_]*)(?<right>[\'\"]?)(?<comment>.*)/)
         found = false
-
         Dir.glob("#{app_project_dir}/build.gradle") do |path|
           begin
             temp_file = Tempfile.new('versioning')
@@ -18,7 +17,7 @@ module Fastlane
                   temp_file.puts line
                   next
                 end
-                line = line.gsub regex, "\\1\\2#{params[:value]}\\3"
+                line = line.gsub regex, "\\k<key>\\k<left>#{params[:value]}\\k<right>\\k<comment>"
                 found = true
                 temp_file.puts line
               end

--- a/lib/fastlane/plugin/android_versioning/actions/set_value_in_build.rb
+++ b/lib/fastlane/plugin/android_versioning/actions/set_value_in_build.rb
@@ -6,19 +6,20 @@ module Fastlane
     class SetValueInBuildAction < Action
       def self.run(params)
         app_project_dir ||= params[:app_project_dir]
+        puts "searching for version code: #{params[:key]}"
+        regex = Regexp.new("(#{params[:key]}\\s+)([\'\"])?.*([\'\"])")
         found = false
+
         Dir.glob("#{app_project_dir}/build.gradle") do |path|
           begin
             temp_file = Tempfile.new('versioning')
             File.open(path, 'r') do |file|
               file.each_line do |line|
-                unless line.include? "#{params[:key]} " and !found
+                unless line.match(regex) and !found
                   temp_file.puts line
                   next
                 end
-                components = line.strip.split(' ')
-                value = components.last.tr("\"", "").tr("\'", "")
-                line.replace line.sub(value, params[:value].to_s)
+                line = line.gsub regex, "\\1\\2#{params[:value]}\\3"
                 found = true
                 temp_file.puts line
               end

--- a/spec/fixtures/app/build.gradle
+++ b/spec/fixtures/app/build.gradle
@@ -4,6 +4,7 @@ android {
     buildToolsVersion "24.0.2"
 
     defaultConfig {
+        applicationIdSuffix ""
         minSdkVersion 14
         targetSdkVersion 22
         versionCode 12345

--- a/spec/set_value_in_build_spec.rb
+++ b/spec/set_value_in_build_spec.rb
@@ -34,4 +34,72 @@ describe Fastlane::Actions::SetValueInBuildAction do
       remove_fixture
     end
   end
+
+  describe "Set a non string value" do
+    before do
+      copy_build_fixture
+    end
+
+    def execute_lane_test
+      Fastlane::FastFile.new.parse("lane :test do
+        set_value_in_build(
+          app_project_dir: \"../**/app\",
+          key: \"versionCode\",
+          value: \"123\"
+        )
+      end").runner.execute(:test)
+    end
+
+    def version_code
+      Fastlane::FastFile.new.parse("lane :test do
+        get_value_from_build(
+          app_project_dir: \"../**/app\",
+          key: \"versionCode\"
+        )
+      end").runner.execute(:test)
+    end
+
+    it "should return incremented version code from build.gradle" do
+      execute_lane_test
+      expect(version_code).to eq("123")
+    end
+
+    after do
+      remove_fixture
+    end
+  end
+
+  describe "Set an empty string" do
+    before do
+      copy_build_fixture
+    end
+
+    def execute_lane_test
+      Fastlane::FastFile.new.parse("lane :test do
+        set_value_in_build(
+          app_project_dir: \"../**/app\",
+          key: \"applicationIdSuffix\",
+          value: \".beta\"
+        )
+      end").runner.execute(:test)
+    end
+
+    def application_id_suffix
+      Fastlane::FastFile.new.parse("lane :test do
+        get_value_from_build(
+          app_project_dir: \"../**/app\",
+          key: \"applicationIdSuffix\"
+        )
+      end").runner.execute(:test)
+    end
+
+    it "should return updated suffix from build.gradle" do
+      execute_lane_test
+      expect(application_id_suffix).to eq(".beta")
+    end
+
+    after do
+      remove_fixture
+    end
+  end
 end

--- a/spec/set_value_in_build_spec.rb
+++ b/spec/set_value_in_build_spec.rb
@@ -35,39 +35,39 @@ describe Fastlane::Actions::SetValueInBuildAction do
     end
   end
 
-  # describe "Set a non string value" do
-  #   before do
-  #     copy_build_fixture
-  #   end
+  describe "Set a non string value" do
+    before do
+      copy_build_fixture
+    end
 
-  #   def execute_lane_test
-  #     Fastlane::FastFile.new.parse("lane :test do
-  #       set_value_in_build(
-  #         app_project_dir: \"../**/app\",
-  #         key: \"versionCode\",
-  #         value: \"123\"
-  #       )
-  #     end").runner.execute(:test)
-  #   end
+    def execute_lane_test
+      Fastlane::FastFile.new.parse("lane :test do
+        set_value_in_build(
+          app_project_dir: \"../**/app\",
+          key: \"versionCode\",
+          value: \"123\"
+        )
+      end").runner.execute(:test)
+    end
 
-  #   def version_code
-  #     Fastlane::FastFile.new.parse("lane :test do
-  #       get_value_from_build(
-  #         app_project_dir: \"../**/app\",
-  #         key: \"versionCode\"
-  #       )
-  #     end").runner.execute(:test)
-  #   end
+    def version_code
+      Fastlane::FastFile.new.parse("lane :test do
+        get_value_from_build(
+          app_project_dir: \"../**/app\",
+          key: \"versionCode\"
+        )
+      end").runner.execute(:test)
+    end
 
-    # it "should return incremented version code from build.gradle" do
-    #   execute_lane_test
-    #   expect(version_code).to eq("123")
-    # end
+    it "should return incremented version code from build.gradle" do
+      execute_lane_test
+      expect(version_code).to eq("123")
+    end
 
-    # after do
-    #   remove_fixture
-    # end
-  # end
+    after do
+      remove_fixture
+    end
+  end
 
   describe "Set an empty string" do
     before do

--- a/spec/set_value_in_build_spec.rb
+++ b/spec/set_value_in_build_spec.rb
@@ -35,39 +35,39 @@ describe Fastlane::Actions::SetValueInBuildAction do
     end
   end
 
-  describe "Set a non string value" do
-    before do
-      copy_build_fixture
-    end
+  # describe "Set a non string value" do
+  #   before do
+  #     copy_build_fixture
+  #   end
 
-    def execute_lane_test
-      Fastlane::FastFile.new.parse("lane :test do
-        set_value_in_build(
-          app_project_dir: \"../**/app\",
-          key: \"versionCode\",
-          value: \"123\"
-        )
-      end").runner.execute(:test)
-    end
+  #   def execute_lane_test
+  #     Fastlane::FastFile.new.parse("lane :test do
+  #       set_value_in_build(
+  #         app_project_dir: \"../**/app\",
+  #         key: \"versionCode\",
+  #         value: \"123\"
+  #       )
+  #     end").runner.execute(:test)
+  #   end
 
-    def version_code
-      Fastlane::FastFile.new.parse("lane :test do
-        get_value_from_build(
-          app_project_dir: \"../**/app\",
-          key: \"versionCode\"
-        )
-      end").runner.execute(:test)
-    end
+  #   def version_code
+  #     Fastlane::FastFile.new.parse("lane :test do
+  #       get_value_from_build(
+  #         app_project_dir: \"../**/app\",
+  #         key: \"versionCode\"
+  #       )
+  #     end").runner.execute(:test)
+  #   end
 
-    it "should return incremented version code from build.gradle" do
-      execute_lane_test
-      expect(version_code).to eq("123")
-    end
+    # it "should return incremented version code from build.gradle" do
+    #   execute_lane_test
+    #   expect(version_code).to eq("123")
+    # end
 
-    after do
-      remove_fixture
-    end
-  end
+    # after do
+    #   remove_fixture
+    # end
+  # end
 
   describe "Set an empty string" do
     before do


### PR DESCRIPTION
Prior to this PR, it was not possible to use this plugin to update an empty string value. We're using this on CI to set an `applicationIdSuffix`, which is blank by default.

Here are screenshots of a file updating a value with an empty string and a string with some characters in it in this branch:

Before running lane:
<img width="276" alt="build gradle mobile 2018-08-01 09-26-45" src="https://user-images.githubusercontent.com/14339/43524570-9e710f58-956d-11e8-8b0a-6772fadac23d.png">

After running lane:
![image](https://user-images.githubusercontent.com/14339/43524833-3fa16d5a-956e-11e8-8534-e97dda1756b7.png)

My hope was to also solve the case of updating integers, but the regex still needs a bit of tweaking for that to work. I have a test for this in the PR, but it is commented out.