### PR TITLE
Feature/automatic increment with current minute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ vendor
 /rdoc/
 fastlane/README.md
 fastlane/report.xml
+
+.idea/

--- a/lib/fastlane/plugin/android_versioning/actions/increment_version_code.rb
+++ b/lib/fastlane/plugin/android_versioning/actions/increment_version_code.rb
@@ -9,11 +9,19 @@ module Fastlane
     class IncrementVersionCodeAction < Action
       def self.run(params)
         current_version_code = GetVersionCodeAction.run(params)
-        new_version_code = params[:version_code].nil? ? current_version_code.to_i + 1 : params[:version_code].to_i
+
+        new_version_code = if params[:version_code].nil?
+                             current_version_code.to_i + 1
+                           elsif params[:version_code] == -1
+                             ((Time.now.to_f * 1000).to_i / (60 * 1000)).to_i
+                           else
+                             params[:version_code].to_i
+                           end
+
         SetValueInBuildAction.run(
-          app_project_dir: params[:app_project_dir],
-          key: "versionCode",
-          value: new_version_code
+            app_project_dir: params[:app_project_dir],
+            key: "versionCode",
+            value: new_version_code
         )
         Actions.lane_context[SharedValues::VERSION_CODE] = new_version_code.to_s
         new_version_code.to_s
@@ -24,17 +32,17 @@ module Fastlane
       #####################################################
       def self.available_options
         [
-          FastlaneCore::ConfigItem.new(key: :app_project_dir,
-                                    env_name: "ANDROID_VERSIONING_APP_PROJECT_DIR",
-                                 description: "The path to the application source folder in the Android project (default: android/app)",
-                                    optional: true,
-                                        type: String,
-                               default_value: "android/app"),
-          FastlaneCore::ConfigItem.new(key: :version_code,
-                                  env_name: "ANDROID_VERSIONING_VERSION_CODE",
-                               description: "Change to a specific version (optional)",
-                                  optional: true,
-                                      type: Integer)
+            FastlaneCore::ConfigItem.new(key: :app_project_dir,
+                                         env_name: "ANDROID_VERSIONING_APP_PROJECT_DIR",
+                                         description: "The path to the application source folder in the Android project (default: android/app)",
+                                         optional: true,
+                                         type: String,
+                                         default_value: "android/app"),
+            FastlaneCore::ConfigItem.new(key: :version_code,
+                                         env_name: "ANDROID_VERSIONING_VERSION_CODE",
+                                         description: "Change to a specific version (optional)",
+                                         optional: true,
+                                         type: Integer)
         ]
       end
 
@@ -44,13 +52,13 @@ module Fastlane
 
       def self.details
         [
-          "This action will increment the version code directly in build.gradle . "
+            "This action will increment the version code directly in build.gradle . "
         ].join("\n")
       end
 
       def self.output
         [
-          ['VERSION_CODE', 'The new version code']
+            ['VERSION_CODE', 'The new version code']
         ]
       end
 

--- a/spec/increment_version_code_spec.rb
+++ b/spec/increment_version_code_spec.rb
@@ -23,6 +23,15 @@ describe Fastlane::Actions::IncrementVersionCodeAction do
       end").runner.execute(:test)
     end
 
+    def execute_lane_automatic_test
+      Fastlane::FastFile.new.parse("lane :test do
+        increment_version_code(
+          app_project_dir: \"../**/app\",
+          version_code: -1
+        )
+      end").runner.execute(:test)
+    end
+
     it "should return incremented version code from build.gradle" do
       expect(execute_lane_test).to eq("12346")
     end
@@ -34,6 +43,11 @@ describe Fastlane::Actions::IncrementVersionCodeAction do
     it "should set VERSION_CODE shared value" do
       result = execute_lane_test
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_CODE]).to eq("12346")
+    end
+
+    it "should set VERSION_CODE to current minute" do
+      expected_result = ((Time.now.to_f * 1000).to_i / (60 * 1000)).to_s
+      expect(execute_lane_automatic_test).to eq(expected_result)
     end
 
     after do

--- a/spec/increment_version_code_spec.rb
+++ b/spec/increment_version_code_spec.rb
@@ -45,7 +45,7 @@ describe Fastlane::Actions::IncrementVersionCodeAction do
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_CODE]).to eq("12346")
     end
 
-    it "should set VERSION_CODE to current minute" do
+    it "should set VERSION_CODE to current minute when option is -1" do
       expected_result = ((Time.now.to_f * 1000).to_i / (60 * 1000)).to_s
       expect(execute_lane_automatic_test).to eq(expected_result)
     end


### PR DESCRIPTION
This adds the possibility to set the version code to the current minute from system time.

When using the `increment_version_code` with option set to `-1`, it will use the `Time` module to set the version code.