### PR TITLE
[FEATURE] Updated set in build regex to allow values containing '-' character

### DIFF
--- a/lib/fastlane/plugin/android_versioning/actions/set_value_in_build.rb
+++ b/lib/fastlane/plugin/android_versioning/actions/set_value_in_build.rb
@@ -6,7 +6,7 @@ module Fastlane
     class SetValueInBuildAction < Action
       def self.run(params)
         app_project_dir ||= params[:app_project_dir]
-        regex = Regexp.new(/(?<key>#{params[:key]}\s+)(?<left>[\'\"]?)(?<value>[a-zA-Z0-9\.\_]*)(?<right>[\'\"]?)(?<comment>.*)/)
+        regex = Regexp.new(/(?<key>#{params[:key]}\s+)(?<left>[\'\"]?)(?<value>[a-zA-Z0-9\-\.\_]*)(?<right>[\'\"]?)(?<comment>.*)/)
         flavor = params[:flavor]
         flavorSpecified = !(flavor.nil? or flavor.empty?)
         regex_flavor = Regexp.new(/[ \t]#{flavor}[ \t]/)


### PR DESCRIPTION
This fix updates the regex to allow - character to occur within the value. 

Because otherwise the value is interpreted as comment and is reattached back into the file when a value is set. This results in duplicate values. 

For example: 
Code Snippet:
```
    productFlavors {
        production {
            versionNameSuffix ''
        }
        staging {
            versionNameSuffix '-staging-3532647'
        }
    }
```

Using
```
set_value_in_build(
      key: "versionNameSuffix", value: '-staging-3532647',
      flavor: 'staging'
    )
```

Results in 

```
versionNameSuffix '-staging-3532647-staging-3532647'
```